### PR TITLE
Print a different error if comments are found

### DIFF
--- a/README.md
+++ b/README.md
@@ -213,6 +213,10 @@ This makes sense in many cases, but possibly not every case.
 
 ## Changelog
 
+### [0.0.7] - unreleased
+
+* Warn if comments are found/don't treat comments as child elements in error messages
+
 ### [0.0.6] - 2020-03-25
 
 * Allow ignored fields via `init=false` or the `ignored` function

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -77,7 +77,7 @@ good-names = "_,e,el,ex,f,tp,k,v,ns"
 indent-string = "    "
 
 [tool.taskipy.tasks]
-isort = "isort -v ."
+isort = "isort ."
 black = "black ."
 mypy = "mypy --strict src/xml_dataclasses/ functional/container_test.py"
 pylint = "pylint src/xml_dataclasses/"

--- a/tests/load_test.py
+++ b/tests/load_test.py
@@ -549,3 +549,33 @@ def test_load_with_validation():
     el = etree.fromstring('<foo bar="baz" />')
     with pytest.raises(MyError):
         load(Foo, el, "foo")
+
+
+def test_load_with_child_comment_not_stripped():
+    @xml_dataclass
+    class Foo:
+        __ns__ = None
+        bar: List[Union[Child1, Child2]]
+
+    el = etree.fromstring('<foo><!-- comment --><bar spam="eggs" /></foo>')
+
+    with pytest.raises(ValueError) as exc_info:
+        load(Foo, el, "foo")
+
+    msg = str(exc_info.value)
+    assert "Element 'foo' contains comments" in msg
+
+
+def test_load_with_text_comment_not_stripped():
+    @xml_dataclass
+    class Foo:
+        __ns__ = None
+        value: str = text()
+
+    el = etree.fromstring("<foo>spam<!-- comment -->eggs</foo>")
+
+    with pytest.raises(ValueError) as exc_info:
+        load(Foo, el, "foo")
+
+    msg = str(exc_info.value)
+    assert "Element 'foo' contains comments" in msg


### PR DESCRIPTION
See #4 . I'd like to not do this, comments should be stripped and it's messing around with `lxml` internals. If there's a better way to identify comments, would love to know (I think `e.tag` returns `"<!---->"`, don't know if that's really much better though)